### PR TITLE
✨ Add space after emoji prefix

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,7 +70,7 @@ function getEnvLanguage(){
 }
 
 function prefixCommit(repository: Repository, prefix: String) {
-	repository.inputBox.value = `${prefix}${repository.inputBox.value}`;
+	repository.inputBox.value = `${prefix} ${repository.inputBox.value}`;
 }
 
 function getGitExtension() {


### PR DESCRIPTION
Thanks for this extension! It makes using Gitmoji a lot easier 🙂

When I started using this extension, I noticed that I wasn't putting spaces after the emoji even though it looks like one is already there (in the commit message box of VSCode).

This adds a space after the prefix.