### PR TITLE
✨ Add configurable additionnal emojis

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,121 +1,121 @@
 {
-	"name": "gitmoji-vscode",
-	"displayName": "Gitmoji",
-	"description": "An emoji tool for your git commit messages",
-	"version": "0.1.7",
-	"author": {
-		"name": "Seaton Jiang",
-		"email": "seaton@vtrois.com"
-	},
-	"publisher": "Vtrois",
-	"license": "MIT",
-	"bugs": {
-		"url": "https://github.com/Vtrois/gitmoji-vscode/issues",
-		"email": "support@vtrois.com"
-	},
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/Vtrois/gitmoji-vscode.git"
-	},
-	"homepage": "https://github.com/Vtrois/gitmoji-vscode/blob/master/README.md",
-	"engines": {
-		"vscode": "^1.40.0"
-	},
-	"keywords": [
-		"git",
-		"emoji",
-		"commit",
-		"messages"
-	],
-	"categories": [
-		"Other"
-	],
-	"icon": "images/icon.png",
-	"activationEvents": [
-		"onCommand:extension.Gitmoji"
-	],
-	"main": "./out/extension.js",
-	"contributes": {
-		"commands": [
-			{
-				"command": "extension.Gitmoji",
-				"title": "Gitmoji: An emoji tool for your git commit messages",
-				"icon": {
-					"dark": "images/icon_dark.svg",
-					"light": "images/icon_light.svg"
-				}
-			}
-		],
-		"menus": {
-			"scm/title": [
-				{
-					"when": "scmProvider == git",
-					"command": "extension.Gitmoji",
-					"group": "navigation"
-				}
-			]
-		},
-		"configuration": {
-			"title": "Gitmoji",
-			"properties": {
-				"gitmoji.outputType": {
-					"type": "string",
-					"default": "emoji",
-					"enum": [
-						"code",
-						"emoji"
-					],
-					"enumDescriptions": [
-						"Suitable for Github, etc.",
-						"Suitable for Github, Gitlab, Coding, etc."
-					],
-					"description": "Configure the type of Gitmoji output"
-				},
-				"gitmoji.additionalEmojis": {
-					"type": "array",
-					"default": [],
-					"items": {
-						"type": "object",
-						"title": "A gitmoji entry",
-						"properties": {
-							"emoji": {
-								"type": "string",
-								"description": "The emoji character"
-							},
-							"code": {
-								"type": "string",
-								"description": "The emoji's :code: (including both colons)"
-							},
-							"description": {
-								"type": "string",
-								"description": "The commit type described by this emoji"
-							},
-							"description_zh_cn": {
-								"type": "string",
-								"description": "A chinese (zh_CN) version of the description. If empty, the english description will be used.",
-								"default": ""
-							}
-						}
-					},
-					"description": "Additional emojis shown in the picker"
-				}
-			}
-		}
-	},
-	"scripts": {
-		"vscode:prepublish": "npm run compile",
-		"compile": "tsc -p ./",
-		"watch": "tsc -watch -p ./",
-		"pretest": "npm run compile"
-	},
-	"devDependencies": {
-		"@types/glob": "^7.1.1",
-		"@types/mocha": "^5.2.7",
-		"@types/node": "^12.11.7",
-		"@types/vscode": "^1.40.0",
-		"glob": "^7.1.5",
-		"mocha": "^6.2.2",
-		"typescript": "^3.6.4",
-		"tslint": "^5.20.0"
-	}
+    "name": "gitmoji-vscode",
+    "displayName": "Gitmoji",
+    "description": "An emoji tool for your git commit messages",
+    "version": "0.1.7",
+    "author": {
+        "name": "Seaton Jiang",
+        "email": "seaton@vtrois.com"
+    },
+    "publisher": "Vtrois",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/Vtrois/gitmoji-vscode/issues",
+        "email": "support@vtrois.com"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Vtrois/gitmoji-vscode.git"
+    },
+    "homepage": "https://github.com/Vtrois/gitmoji-vscode/blob/master/README.md",
+    "engines": {
+        "vscode": "^1.40.0"
+    },
+    "keywords": [
+        "git",
+        "emoji",
+        "commit",
+        "messages"
+    ],
+    "categories": [
+        "Other"
+    ],
+    "icon": "images/icon.png",
+    "activationEvents": [
+        "onCommand:extension.Gitmoji"
+    ],
+    "main": "./out/extension.js",
+    "contributes": {
+        "commands": [
+            {
+                "command": "extension.Gitmoji",
+                "title": "Gitmoji: An emoji tool for your git commit messages",
+                "icon": {
+                    "dark": "images/icon_dark.svg",
+                    "light": "images/icon_light.svg"
+                }
+            }
+        ],
+        "menus": {
+            "scm/title": [
+                {
+                    "when": "scmProvider == git",
+                    "command": "extension.Gitmoji",
+                    "group": "navigation"
+                }
+            ]
+        },
+        "configuration": {
+            "title": "Gitmoji",
+            "properties": {
+                "gitmoji.outputType": {
+                    "type": "string",
+                    "default": "emoji",
+                    "enum": [
+                        "code",
+                        "emoji"
+                    ],
+                    "enumDescriptions": [
+                        "Suitable for Github, etc.",
+                        "Suitable for Github, Gitlab, Coding, etc."
+                    ],
+                    "description": "Configure the type of Gitmoji output"
+                },
+                "gitmoji.additionalEmojis": {
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "object",
+                        "title": "A gitmoji entry",
+                        "properties": {
+                            "emoji": {
+                                "type": "string",
+                                "description": "The emoji character"
+                            },
+                            "code": {
+                                "type": "string",
+                                "description": "The emoji's :code: (including both colons)"
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "The commit type described by this emoji"
+                            },
+                            "description_zh_cn": {
+                                "type": "string",
+                                "description": "A chinese (zh_CN) version of the description. If empty, the english description will be used.",
+                                "default": ""
+                            }
+                        }
+                    },
+                    "description": "Additional emojis shown in the picker"
+                }
+            }
+        }
+    },
+    "scripts": {
+        "vscode:prepublish": "npm run compile",
+        "compile": "tsc -p ./",
+        "watch": "tsc -watch -p ./",
+        "pretest": "npm run compile"
+    },
+    "devDependencies": {
+        "@types/glob": "^7.1.1",
+        "@types/mocha": "^5.2.7",
+        "@types/node": "^12.11.7",
+        "@types/vscode": "^1.40.0",
+        "glob": "^7.1.5",
+        "mocha": "^6.2.2",
+        "typescript": "^3.6.4",
+        "tslint": "^5.20.0"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,34 @@
 						"Suitable for Github, Gitlab, Coding, etc."
 					],
 					"description": "Configure the type of Gitmoji output"
+				},
+				"gitmoji.additionalEmojis": {
+					"type": "array",
+					"default": [],
+					"items": {
+						"type": "object",
+						"title": "A gitmoji entry",
+						"properties": {
+							"emoji": {
+								"type": "string",
+								"description": "The emoji character"
+							},
+							"code": {
+								"type": "string",
+								"description": "The emoji's :code: (including both colons)"
+							},
+							"description": {
+								"type": "string",
+								"description": "The commit type described by this emoji"
+							},
+							"description_zh_cn": {
+								"type": "string",
+								"description": "A chinese (zh_CN) version of the description. If empty, the english description will be used.",
+								"default": ""
+							}
+						}
+					},
+					"description": "Additional emojis shown in the picker"
 				}
 			}
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,85 +4,82 @@ import Gitmoji from './gitmoji/gitmoji';
 
 export function activate(context: vscode.ExtensionContext) {
 
-	let disposable = vscode.commands.registerCommand('extension.Gitmoji', (uri?) => {
-		const git = getGitExtension();
-		const language = getEnvLanguage();
+    let disposable = vscode.commands.registerCommand('extension.Gitmoji', (uri?) => {
+        const git = getGitExtension();
+        const language = getEnvLanguage();
 
-		if (!git) {
-			vscode.window.showErrorMessage('Unable to load Git Extension');
-			return;
-		}
-
-      let additionalEmojis: Array<any> =
-        vscode.workspace.getConfiguration().get("gitmoji.additionalEmojis") ||
-				[];
-
-      let emojis = [...Gitmoji, ...additionalEmojis];
-		let items = [];
-      if (language === "zh-cn") {
-        for (let i = 0; i < emojis.length; i++) {
-          items.push({
-            label: `${emojis[i].emoji}  ${emojis[i].description_zh_cn ||
-              emojis[i].description}`,
-            code: emojis[i].code,
-            emoji: emojis[i].emoji
-          });
+        if (!git) {
+            vscode.window.showErrorMessage('Unable to load Git Extension');
+            return;
         }
-      } else {
-        for (let i = 0; i < emojis.length; i++) {
-          items.push({
-            label: `${emojis[i].emoji} ${emojis[i].description}`,
-            code: emojis[i].code,
-            emoji: emojis[i].emoji
-          });
+
+        let additionalEmojis: Array<any> = vscode.workspace.getConfiguration().get("gitmoji.additionalEmojis") || [];
+        let emojis = [...Gitmoji, ...additionalEmojis];
+        let items = [];
+
+        if (language === "zh-cn") {
+            for (let i = 0; i < emojis.length; i++) {
+                items.push({
+                label: `${emojis[i].emoji} ${emojis[i].description_zh_cn || emojis[i].description}`,
+                code: emojis[i].code,
+                emoji: emojis[i].emoji
+                });
+            }
+        } else {
+            for (let i = 0; i < emojis.length; i++) {
+                items.push({
+                label: `${emojis[i].emoji} ${emojis[i].description}`,
+                code: emojis[i].code,
+                emoji: emojis[i].emoji
+                });
+            }
         }
-      }
 
-		vscode.window.showQuickPick(items).then(function (selected) {
-			if (selected) {
-				vscode.commands.executeCommand('workbench.view.scm');
-				let outputType = vscode.workspace.getConfiguration().get('gitmoji.outputType');
+        vscode.window.showQuickPick(items).then(function (selected) {
+            if (selected) {
+                vscode.commands.executeCommand('workbench.view.scm');
+                let outputType = vscode.workspace.getConfiguration().get('gitmoji.outputType');
 
-				if (uri) {
-					let selectedRepository = git.repositories.find(repository => {
-						return repository.rootUri.path === uri._rootUri.path;
-					});
-					if (selectedRepository) {
-						if (outputType === "emoji"){
-							prefixCommit(selectedRepository, selected.emoji);
-						} else {
-							prefixCommit(selectedRepository, selected.code);
-						}
-					}
-				} else {
-					for (let repo of git.repositories) {
-						if (outputType === "emoji"){
-							prefixCommit(repo, selected.emoji);
-						} else {
-							prefixCommit(repo, selected.code);
-						}
-					}
-				}
-			}
-		});
-	});
+                if (uri) {
+                    let selectedRepository = git.repositories.find(repository => {
+                        return repository.rootUri.path === uri._rootUri.path;
+                    });
+                    if (selectedRepository) {
+                        if (outputType === "emoji"){
+                            prefixCommit(selectedRepository, selected.emoji);
+                        } else {
+                            prefixCommit(selectedRepository, selected.code);
+                        }
+                    }
+                } else {
+                    for (let repo of git.repositories) {
+                        if (outputType === "emoji"){
+                            prefixCommit(repo, selected.emoji);
+                        } else {
+                            prefixCommit(repo, selected.code);
+                        }
+                    }
+                }
+            }
+        });
+    });
 
-	context.subscriptions.push(disposable);
+    context.subscriptions.push(disposable);
 }
 
 function getEnvLanguage(){
-	const language = vscode.env.language;
-	return language;
+    const language = vscode.env.language;
+    return language;
 }
 
 function prefixCommit(repository: Repository, prefix: String) {
-	repository.inputBox.value = `${prefix} ${repository.inputBox.value}`;
+    repository.inputBox.value = `${prefix} ${repository.inputBox.value}`;
 }
 
 function getGitExtension() {
-	const vscodeGit = vscode.extensions.getExtension<GitExtension>('vscode.git');
-	const gitExtension = vscodeGit && vscodeGit.exports;
-	return gitExtension && gitExtension.getAPI(1);
+    const vscodeGit = vscode.extensions.getExtension<GitExtension>('vscode.git');
+    const gitExtension = vscodeGit && vscodeGit.exports;
+    return gitExtension && gitExtension.getAPI(1);
 }
 
 export function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,24 +13,30 @@ export function activate(context: vscode.ExtensionContext) {
 			return;
 		}
 
+      let additionalEmojis: Array<any> =
+        vscode.workspace.getConfiguration().get("gitmoji.additionalEmojis") ||
+				[];
+
+      let emojis = [...Gitmoji, ...additionalEmojis];
 		let items = [];
-		if(language === "zh-cn"){
-			for (let i = 0; i < Gitmoji.length; i++) {
-				items.push({
-					label: `${Gitmoji[i].emoji}  ${Gitmoji[i].description_zh_cn}`,
-					code: Gitmoji[i].code,
-					emoji: Gitmoji[i].emoji
-				});
-			}
-		}else{
-			for (let i = 0; i < Gitmoji.length; i++) {
-				items.push({
-					label: `${Gitmoji[i].emoji} ${Gitmoji[i].description}`,
-					code: Gitmoji[i].code,
-					emoji: Gitmoji[i].emoji
-				});
-			}
-		}
+      if (language === "zh-cn") {
+        for (let i = 0; i < emojis.length; i++) {
+          items.push({
+            label: `${emojis[i].emoji}  ${emojis[i].description_zh_cn ||
+              emojis[i].description}`,
+            code: emojis[i].code,
+            emoji: emojis[i].emoji
+          });
+        }
+      } else {
+        for (let i = 0; i < emojis.length; i++) {
+          items.push({
+            label: `${emojis[i].emoji} ${emojis[i].description}`,
+            code: emojis[i].code,
+            emoji: emojis[i].emoji
+          });
+        }
+      }
 
 		vscode.window.showQuickPick(items).then(function (selected) {
 			if (selected) {


### PR DESCRIPTION
Sorry if the formatting messes with your formatter, we haven't got the same configurations...

I don't know how vscode extension works (or how even TS works) but I was able to get this working and tested it successfully after packaging the extension (with `vsce package`) and installing the `.vsix`

Anyway, this is pretty useful if you want to add additionnal emojis, extending beyond the gitmoji standard.

I also thought about adding `removeEmojis` (by code?) or `overrideEmojis` (same as `additionnalEmojis` but does not load the `Gitmoji` thingie from `gitmoji.ts`) but I really should be working on something else right now...

I hope the ES6 feature I used (spread syntax `[...arr1, ...arr2]`) is supported in your setup, if not you can replace it with a `.push()` call to add additional emojis to the list.

Also, I didn't bump the version number though, as I'm not sure if you follow SemVer or not, and what number you would increase 