### PR TITLE
Command to insert markdown emoji key

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 This project provides an easy solution for using [Gitmoji](https://github.com/carloscuesta/gitmoji) from VSCode Extension. gitmoji-vscode solves the hassle of searching through the gitmoji list. Includes a bunch of options you can play with! 🎉
 
+This extension also includes a command to insert a markdown table of _your_ emojis and their meanings, so that you can clearly define in your `CONTRIBUTING.md` how contributors should name their commits
+
 ## Install
 
 1. Open [Visual Studio Code](https://code.visualstudio.com/)

--- a/package.json
+++ b/package.json
@@ -122,5 +122,9 @@
         "mocha": "^6.2.2",
         "typescript": "^3.6.4",
         "tslint": "^5.20.0"
+    },
+    "dependencies": {
+        "@types/markdown-table": "^2.0.0",
+        "markdown-table": "^2.0.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -32,25 +32,30 @@
     ],
     "icon": "images/icon.png",
     "activationEvents": [
-        "onCommand:extension.Gitmoji"
+        "onCommand:extension.Gitmoji.pickEmoji",
+        "onCommand:extension.Gitmoji.insertMarkdownEmojiKey"
     ],
     "main": "./out/extension.js",
     "contributes": {
         "commands": [
             {
-                "command": "extension.Gitmoji",
-                "title": "Gitmoji: An emoji tool for your git commit messages",
+                "command": "extension.Gitmoji.pickEmoji",
+                "title": "Gitmoji: Add emoji to commit message",
                 "icon": {
                     "dark": "images/icon_dark.svg",
                     "light": "images/icon_light.svg"
                 }
+            },
+            {
+                "command": "extension.Gitmoji.insertMarkdownEmojiKey",
+                "title": "Gitmoji: Insert markdown emoji key table"
             }
         ],
         "menus": {
             "scm/title": [
                 {
                     "when": "scmProvider == git",
-                    "command": "extension.Gitmoji",
+                    "command": "extension.Gitmoji.pickEmoji",
                     "group": "navigation"
                 }
             ]
@@ -120,8 +125,8 @@
         "@types/vscode": "^1.40.0",
         "glob": "^7.1.5",
         "mocha": "^6.2.2",
-        "typescript": "^3.6.4",
-        "tslint": "^5.20.0"
+        "tslint": "^5.20.0",
+        "typescript": "^3.6.4"
     },
     "dependencies": {
         "@types/markdown-table": "^2.0.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import { stringify } from 'querystring';
 
 export function activate(context: vscode.ExtensionContext) {
 
-    let disposable = vscode.commands.registerCommand('extension.Gitmoji.pickEmoji', (uri?) => {
+    let pickCommand = vscode.commands.registerCommand('extension.Gitmoji.pickEmoji', (uri?) => {
         const git = getGitExtension();
         const language = getEnvLanguage();
 
@@ -66,9 +66,9 @@ export function activate(context: vscode.ExtensionContext) {
         });
     });
 
-    context.subscriptions.push(disposable);
+    context.subscriptions.push(pickCommand);
 
-    let disposable2 = vscode.commands.registerCommand('extension.Gitmoji.insertMarkdownEmojiKey', () => {
+    let insertMarkdownEmojiKeyCommand = vscode.commands.registerCommand('extension.Gitmoji.insertMarkdownEmojiKey', () => {
         const editor = vscode.window.activeTextEditor;
         if (editor) {
             const document = editor.document
@@ -79,7 +79,7 @@ export function activate(context: vscode.ExtensionContext) {
         }
     });
 
-    context.subscriptions.push(disposable2);
+    context.subscriptions.push(insertMarkdownEmojiKeyCommand);
 }
 
 function getEnvLanguage() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,6 @@ import { stringify } from 'querystring';
 export function activate(context: vscode.ExtensionContext) {
 
     let disposable = vscode.commands.registerCommand('extension.Gitmoji.pickEmoji', (uri?) => {
-        vscode.window.showInformationMessage('YES! YES! YES! YES! YES! YES! YES! YES! ')
         const git = getGitExtension();
         const language = getEnvLanguage();
 

--- a/src/gitmoji/gitmoji.ts
+++ b/src/gitmoji/gitmoji.ts
@@ -408,4 +408,4 @@ let Gitmoji: Array<Emoji> = [
         "description_zh_cn": "需要清理的弃用代码"
     }
 ];
-export default Gitmoji ;
+export { Gitmoji, Emoji } ;


### PR DESCRIPTION
This pull requests adds a new command to insert a markdown table of _your_ emojis and their meanings, so that you can clearly define in your `CONTRIBUTING.md` how contributors should name their commits.

As the extension now has two commands, I had to rename the "pick emoji" one

