### PR TITLE
✏️ fix: lower case "Remove"

### DIFF
--- a/src/gitmoji/gitmoji.ts
+++ b/src/gitmoji/gitmoji.ts
@@ -392,7 +392,7 @@ let Gitmoji: Array<Emoji> = [
   {
     emoji: "🚩",
     code: ":triangular_flag_on_post:",
-    description: "Add, update, or Remove feature flags",
+    description: "Add, update, or remove feature flags",
     description_zh_cn: "添加、更新或删除特性标志",
   },
   {


### PR DESCRIPTION
This change removes the awkward capitalized "R" in "Remove" for the gitmoji "Add, update, or remove feature flags." This is consistent with gitmoji website https://gitmoji.carloscuesta.me/. 