### PR TITLE
Search by emoji code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
   "search.exclude": {
     "out": true
   },
-  "typescript.tsc.autoDetect": "off"
+  "typescript.tsc.autoDetect": "off",
+  "standard.enable": false
 }

--- a/package.json
+++ b/package.json
@@ -102,6 +102,11 @@
           "type": "boolean",
           "default": false,
           "description": "Use your additional emojis instead the ones from the extension"
+        },
+        "gitmoji.showEmojiCode": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable searching gitmojis by emoji code (example: ambulance will return hotfix)"
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,9 @@ export function activate(context: vscode.ExtensionContext) {
       let additionalEmojis: Array<any> =
         vscode.workspace.getConfiguration().get("gitmoji.additionalEmojis") ||
         [];
+
+      const showEmojiCode: boolean | undefined = vscode.workspace.getConfiguration().get("gitmoji.showEmojiCode")
+
       let emojis = [];
       let onlyUseAdditionalEmojis:
         | boolean
@@ -30,27 +33,26 @@ export function activate(context: vscode.ExtensionContext) {
         emojis = [...Gitmoji, ...additionalEmojis];
       }
 
-      let items = [];
-
-      if (language === "zh-cn") {
-        for (let i = 0; i < emojis.length; i++) {
-          items.push({
-            label: `${emojis[i].emoji} ${
-              emojis[i].description_zh_cn || emojis[i].description
-            }`,
-            code: emojis[i].code,
-            emoji: emojis[i].emoji,
-          });
+      const items = emojis.map((emojiObj) => {
+        const { 
+          description, 
+          description_zh_cn,
+          code: _code,
+          emoji
+        } = emojiObj
+        const displayDescription = language === "zh-cn"
+          ? description_zh_cn || description
+          : description
+        const code = showEmojiCode
+          ? _code
+          : ''
+        const label = `${emoji} ${displayDescription} ${code}`
+        return {
+          label,
+          code,
+          emoji
         }
-      } else {
-        for (let i = 0; i < emojis.length; i++) {
-          items.push({
-            label: `${emojis[i].emoji} ${emojis[i].description}`,
-            code: emojis[i].code,
-            emoji: emojis[i].emoji,
-          });
-        }
-      }
+      })
 
       vscode.window.showQuickPick(items).then(function (selected) {
         if (selected) {

--- a/src/gitmoji/gitmoji.ts
+++ b/src/gitmoji/gitmoji.ts
@@ -371,5 +371,11 @@ let Gitmoji: Array<Emoji> = [
     description: "Work on code related to authorization, roles and permissions",
     description_zh_cn: "编写与授权、角色和权限有关的代码"
   },
+  {
+    emoji: "🩹",
+    code: ":adhesive_bandage:",
+    description: "Simple fix for a non-critical issue",
+    description_zh_cn: "简单解决非关键问题"
+  },
 ];
 export default Gitmoji;


### PR DESCRIPTION
Search gitmojis by using the emoji name. Implemented as option, not turned on by default.

Only got it working by adding the emoji code in the label of the QuickSearchItem.

Fixes #9 